### PR TITLE
(Fix) Do not crash if torrent has malformed source flag

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,7 +71,10 @@ def main():
                 api = ops
                 new_sources = ops_sources
             else:
-                p.skipped.print(f"Skipped: Source flag is {source.decode('utf8')}.")
+                try:
+                    p.skipped.print(f"Skipped: Source flag is {source.decode('utf8')}.")
+                except AttributeError:
+                    p.skipped.print("Skipped: Source flag is malformed.")
                 continue
 
         found_infohash_match = False


### PR DESCRIPTION
While running encountered a torrent that had a source flag of 0 (integer).  Causes a crash on this print statement.

```
Traceback (most recent call last):
  File "C:\Users\me\Desktop\crops\src\main.py", line 160, in <module>
    main()
  File "C:\Users\me\Desktop\crops\src\main.py", line 74, in main
    p.skipped.print(f"Skipped: Source flag is {source.decode('utf8')}.")
                                               ^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'decode'
```