### PR TITLE
[FEAT] Add `--lookup` option, which stores a json mapping of existing and new hashes to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,34 @@ cython_debug/
 #.idea/
 .vscode/settings.json
 .vscode/tasks.json
+
+# Extra
+/tmp*
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/src/args.py
+++ b/src/args.py
@@ -47,5 +47,11 @@ def get_args():
         action="store_true",
         help="download final .torrent files instead of generating them",
     )
+    extras.add_argument(
+        "--lookup",
+        action="store_true",
+        help="creates hash-lookup.json in folder_out which contains a mapping of \
+        matched/old hashes to hashes of download/created .torrent files"
+    )
 
     return parser.parse_args()

--- a/src/filesystem.py
+++ b/src/filesystem.py
@@ -1,4 +1,4 @@
-import os
+import os, json
 
 
 def get_filename(path):
@@ -16,3 +16,7 @@ def get_files(input_folder, extension=".torrent"):
         for filename in os.listdir(input_folder)
         if filename.endswith(extension)
     ]
+
+def write_json(json_dict: dict, folder: str, filename: str): 
+    with open(os.path.join(folder, filename), 'w') as f: 
+        json.dump(json_dict, f)

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,3 +1,7 @@
+# type:ignore
+# Supress pylance error as this module overrides a stdlib module of same name
+# maybe rename file...
+
 from hashlib import sha1
 
 import bencoder


### PR DESCRIPTION
This flag creates a hash-lookup.json file in the output directory, that contains a mapping of existing hashes (found in input directory) and new hashes of created/downloaded torrent files. It enables writing scripts to automatically import your generated torrent files by looking up the existing torrent and copying its file path.

I have written a script to do this for [transmission](https://github.com/deafmute1/transmission-add-crops). 
This option makes writing such a script for any client with rpc/api access fairly trivial.

Side note for the maintainer of this fork: @resu-detcader - perhaps consider merging `latest` into `main`, because this fork is much superior than the original imo but all the commits are hidden under a non-default branch.